### PR TITLE
Improves extend

### DIFF
--- a/digneapy/archives/_cvt_archive.py
+++ b/digneapy/archives/_cvt_archive.py
@@ -191,6 +191,16 @@ class CVTArchive(Archive):
             self.extend(instances)
 
     @property
+    def descriptors(self) -> np.ndarray:
+        """Descriptors of the instances
+
+        Returns:
+            np.ndarray: Returns a np.ndarray with the descriptors of
+                the instances stored in the archive
+        """
+        return np.asarray(list(self._storage[Keys.descriptors].values()))
+
+    @property
     def dimensions(self) -> int:
         """Dimensions of the measure space used
 

--- a/digneapy/archives/_grid_archive.py
+++ b/digneapy/archives/_grid_archive.py
@@ -101,6 +101,16 @@ class GridArchive(Archive):
             self.extend(instances)
 
     @property
+    def descriptors(self) -> np.ndarray:
+        """Descriptors of the instances
+
+        Returns:
+            np.ndarray: Returns a np.ndarray with the descriptors of
+                the instances stored in the archive
+        """
+        return np.asarray(list(self._storage[Keys.descriptors].values()))
+
+    @property
     def dimensions(self) -> np.ndarray:
         """Dimensions of the GridArchive
 

--- a/digneapy/archives/_unstructured.py
+++ b/digneapy/archives/_unstructured.py
@@ -77,16 +77,6 @@ class UnstructuredArchive(Archive):
         """
         return self._novelty_threshold
 
-    @property
-    def descriptors(self) -> np.ndarray:
-        """Descriptors of the instances
-
-        Returns:
-            np.ndarray: Returns a np.ndarray with the descriptors of
-                the instances stored in the archive
-        """
-        return np.asarray(list(self._storage[Keys.descriptors].values()))
-
     def __str__(self):
         return f"UnstructuredArchive(k={self._k},threshold={self._novelty_threshold},data=(|{len(self)}|))"
 

--- a/digneapy/archives/_unstructured.py
+++ b/digneapy/archives/_unstructured.py
@@ -77,6 +77,16 @@ class UnstructuredArchive(Archive):
         """
         return self._novelty_threshold
 
+    @property
+    def descriptors(self) -> np.ndarray:
+        """Descriptors of the instances
+
+        Returns:
+            np.ndarray: Returns a np.ndarray with the descriptors of
+                the instances stored in the archive
+        """
+        return np.asarray(list(self._storage[Keys.descriptors].values()))
+
     def __str__(self):
         return f"UnstructuredArchive(k={self._k},threshold={self._novelty_threshold},data=(|{len(self)}|))"
 

--- a/digneapy/core/_instance.py
+++ b/digneapy/core/_instance.py
@@ -152,21 +152,23 @@ class Instance:
         return self._dtype
 
     def clone(self) -> Self:
-        """Create a clone of the current instance. More efficient than using copy.deepcopy.
+        """Create a clone of the current instance.
+
+        This avoids Python-level list/tuple conversions by copying the underlying
+        NumPy arrays directly.
 
         Returns:
             Self: Instance object
         """
-        return type(self)(
-            variables=list(self._variables),
-            fitness=self._fitness,
-            performance_bias=self._performance_bias,
-            novelty=self._novelty,
-            descriptor=tuple(self._descriptor) if len(self._descriptor) > 0 else None,
-            portfolio_scores=tuple(self._portfolio_scores)
-            if len(self._portfolio_scores) > 0
-            else None,
-        )
+        new_instance = object.__new__(type(self))
+        new_instance._dtype = self._dtype
+        new_instance._fitness = self._fitness
+        new_instance._performance_bias = self._performance_bias
+        new_instance._novelty = self._novelty
+        new_instance._variables = self._variables.copy()
+        new_instance._descriptor = self._descriptor.copy()
+        new_instance._portfolio_scores = self._portfolio_scores.copy()
+        return new_instance
 
     def clone_with(self, **overrides):
         """Clones an Instance with overriden attributes

--- a/digneapy/visualize/_archive_plotter.py
+++ b/digneapy/visualize/_archive_plotter.py
@@ -20,7 +20,7 @@ from digneapy.archives import GridArchive
 
 
 def _archive_to_matrix(archive: GridArchive, attr: str = "p") -> np.ndarray:
-    """Converts a 2-D GridArchive to a (rows × cols) float matrix.
+    """Converts a 2d GridArchive to a (rows × cols) float matrix.
 
     Empty cells are filled with NaN so they render as a neutral colour.
 
@@ -29,7 +29,7 @@ def _archive_to_matrix(archive: GridArchive, attr: str = "p") -> np.ndarray:
         attr:    Instance attribute to use as cell value. Defaults to ``"p"``.
 
     Returns:
-        2-D numpy array of shape ``(dims[0], dims[1])``.
+        2d numpy array of shape ``(dims[0], dims[1])``.
     """
     rows, cols = int(archive.dimensions[0]), int(archive.dimensions[1])
     matrix = np.full((rows, cols), np.nan, dtype=np.float64)
@@ -37,10 +37,11 @@ def _archive_to_matrix(archive: GridArchive, attr: str = "p") -> np.ndarray:
     if len(archive) == 0:
         return matrix
 
-    flat_indices = np.array(list(archive._storage.keys()), dtype=int)
+    flat_indices = np.array(list(archive.filled_cells))
+    _instances = archive.retrieve_filled_cells(flat_indices)
     grid_indices = archive.int_to_grid_index(flat_indices)  # (n, 2)
-    values = np.array(
-        [getattr(archive._storage[idx], attr) for idx in flat_indices],
+    values = np.asarray(
+        [getattr(instance, attr) for instance in _instances],
         dtype=np.float64,
     )
     matrix[grid_indices[:, 0], grid_indices[:, 1]] = values
@@ -93,7 +94,7 @@ class ArchivePlotter:
     ):
         if len(archive.dimensions) != 2:
             raise ValueError(
-                "ArchivePlotter only supports 2-D GridArchives. "
+                "ArchivePlotter only supports 2d GridArchives. "
                 f"Got dimensions={archive.dimensions}"
             )
 


### PR DESCRIPTION
Improves the performance of extend methods in GridArchive.
Instance.clone() method has been rewritten to speedup the cloning of
Instances without sacrificing the memory integrity. 

If we managed to remove cloned method entirely, the performance can be significantly improved.